### PR TITLE
fix avatar overflow on smaller screens

### DIFF
--- a/src/assets/scss/pages/_freelancer.scss
+++ b/src/assets/scss/pages/_freelancer.scss
@@ -82,13 +82,8 @@
 .freelancer-basic {
   .avatar {
     img {
-      width: 12rem;
-      height: 12rem;
-
-      @include media-breakpoint-up(xl) {
-        width: 15rem;
-        height: 15rem;
-      }
+      width: 100%;
+      height: 100%;
     }
   }
 }


### PR DESCRIPTION
This fixes overflow of avatar images on freelancer detail view when browsing for freelancers.

Tested on Chrome, Firefox, Smaller screens using developer tools.